### PR TITLE
Introduce new badge prop to tab header.

### DIFF
--- a/src/TabScreen.tsx
+++ b/src/TabScreen.tsx
@@ -5,6 +5,7 @@ import type { GestureResponderEvent } from 'react-native';
 export interface TabScreenProps {
   label: string;
   icon?: IconSource;
+  badge?: string | number | boolean;
   children: any;
   onPress?: (event: GestureResponderEvent) => void;
   onPressIn?: (event: GestureResponderEvent) => void;

--- a/src/TabsHeaderItem.tsx
+++ b/src/TabsHeaderItem.tsx
@@ -7,7 +7,7 @@ import {
   Platform,
   TextProps,
 } from 'react-native';
-import { Text, TouchableRipple } from 'react-native-paper';
+import { Badge, Text, TouchableRipple } from 'react-native-paper';
 import type { ReactElement } from 'react';
 import type { TabScreenProps } from './TabScreen';
 import type { Theme } from 'react-native-paper/lib/typescript/types';
@@ -119,6 +119,25 @@ export default function TabsHeaderItem({
                 style={{ color: color, opacity }}
                 size={24}
               />
+              {tab.props.badge ? <View
+                style={[
+                  styles.badgeContainer,
+                  {
+                    right:
+                      (tab.props.badge != null && typeof tab.props.badge !== 'boolean'
+                        ? String(tab.props.badge).length * -2
+                        : 0) - 2,
+                  },
+                ]}
+              >
+                {typeof tab.props.badge === 'boolean' ? (
+                  <Badge visible={tab.props.badge} size={8} />
+                ) : (
+                    <Badge visible={tab.props.badge != null} size={16}>
+                      {tab.props.badge}
+                  </Badge>
+                )}
+              </View> : null}
             </View>
           ) : null}
           {showTextLabel ? (
@@ -140,6 +159,11 @@ export default function TabsHeaderItem({
 }
 
 const styles = StyleSheet.create({
+  badgeContainer: {
+    position: 'absolute',
+    left: 0,
+    top: -2,
+  },
   tabRoot: { position: 'relative' },
   tabRootFixed: { flex: 1 },
   touchableRipple: {


### PR DESCRIPTION
- [x] Introduces a new `badge` prop which will display a [badge](https://callstack.github.io/react-native-paper/badge.html) like so

<img width="393" alt="Screen Shot 2022-01-02 at 3 21 15 PM" src="https://user-images.githubusercontent.com/7604441/147888478-481b487e-8b09-457f-b6ff-449f0bb56327.png">

_Additional Resources_

- https://callstack.github.io/react-native-paper/badge.html
- https://material.io/components/tabs/android#using-tabs
