### PR TITLE
adding badgeStyle props

### DIFF
--- a/src/TabScreen.tsx
+++ b/src/TabScreen.tsx
@@ -6,6 +6,7 @@ export interface TabScreenProps {
   label: string;
   icon?: IconSource;
   badge?: string | number | boolean;
+  badgeStyle?: React.CSSProperties;
   children: any;
   onPress?: (event: GestureResponderEvent) => void;
   onPressIn?: (event: GestureResponderEvent) => void;

--- a/src/TabsHeaderItem.tsx
+++ b/src/TabsHeaderItem.tsx
@@ -138,9 +138,9 @@ export default function TabsHeaderItem({
               ]}
             >
               {badgeWithoutContent ? (
-                <Badge visible={true} size={8} />
+                <Badge visible={true} size={8} style={tab.props.badgeStyle} />
               ) : (
-                <Badge visible={true} size={16}>
+                <Badge visible={true} size={16} style={tab.props.badgeStyle}>
                   {tab.props.badge as any}
                 </Badge>
               )}


### PR DESCRIPTION
Hello,

I have added a badgeStyle props as commented in the issue https://github.com/web-ridge/react-native-paper-tabs/issues/67

I wanted to include all the badgeProps in this props as in the example :
`badgeProps={mybadgeProps}`

but i dont know what kind of interface type i should use :
```
export interface TabScreenProps {
   label: string;
   icon?: IconSource;
   badge?: string | number | boolean;
   badgeProps?: ???;
   children: any;
   onPress?: (event: GestureResponderEvent) => void;
   onPressIn?: (event: GestureResponderEvent) => void;

```

I dont know much Typescript so if you want me to add more props and not just the style i can do a new PR later but i would appreciate if you can indicate me the type of the props i should put.

Meanwhile i hope this PR will be useful and thank you for this nice library ;)

