### PR TITLE
Fix infinite tab switching issue in Swiper.native component

### DIFF
--- a/src/Swiper.native.tsx
+++ b/src/Swiper.native.tsx
@@ -60,9 +60,11 @@ function SwiperNative(props: SwiperProps) {
     (e) => {
       isScrolling.current = false;
       const i = e.nativeEvent.position;
-      goTo(i);
+      if (i !== index) {
+        goTo(i);
+      }
     },
-    [isScrolling, goTo]
+    [isScrolling, goTo, index]
   );
 
   const renderProps = {


### PR DESCRIPTION
Prevent unnecessary calls to goTo function when switching tabs. This resolves the infinite loop of tab changes that occurred due to simultaneous interactions between the TabsHeaderItem and the Swiper.native.