### PR TITLE
fix: provide theme override to Badge

### DIFF
--- a/src/TabsHeaderItem.tsx
+++ b/src/TabsHeaderItem.tsx
@@ -153,9 +153,9 @@ export default function TabsHeaderItem({
               ]}
             >
               {badgeWithoutContent ? (
-                <Badge visible={true} size={8} />
+                <Badge visible={true} size={8} theme={theme} />
               ) : (
-                <Badge visible={true} size={16}>
+                <Badge visible={true} size={16} theme={theme}>
                   {tab.props.badge as any}
                 </Badge>
               )}


### PR DESCRIPTION
`TabHeaderItem` was not passing the `theme` override prop on to the underlying Badge component.

With this change, theme overrides now apply to the Badge as expected.