### PR TITLE
fix: only log 'no layout' when there is no current layout

### DIFF
--- a/src/TabsHeader.tsx
+++ b/src/TabsHeader.tsx
@@ -112,7 +112,7 @@ export default function TabsHeader({
 
   const updateScroll = React.useCallback(
     (scrollType?: 'next' | 'prev') => {
-      if (!layouts.current || mode !== 'scrollable') {
+      if (!layouts.current) {
         console.log('returning no layout');
         return;
       }
@@ -155,7 +155,7 @@ export default function TabsHeader({
         });
       }
     },
-    [mode, layouts, index, scrollRef, scrollX, tabsLayout]
+    [layouts, index, scrollRef, scrollX, tabsLayout]
   );
 
   // subscribes to offset on native devices to scroll tab bar faster when scrolling (iOS only since Android bugs)


### PR DESCRIPTION
Fixes #81.

The code used to non-conditionally log "returning no layout" when in `fixed` mode. This patch solves that.