### PR TITLE
fix: Tabs switch on their own.

### DIFF
--- a/src/Swiper.native.tsx
+++ b/src/Swiper.native.tsx
@@ -60,6 +60,7 @@ function SwiperNative(props: SwiperProps) {
 
   const onPageSelected = React.useCallback(
     (e: any) => {
+      if (isScrolling.current) return;
       isScrolling.current = false;
       const i = e.nativeEvent.position;
       goTo(i);


### PR DESCRIPTION
When `onPageSelected` is triggered we checking `isScrolling`. If variable is true, return.
See #84 for demonstration.